### PR TITLE
Fix emissive import & export

### DIFF
--- a/Packages/net.yutopp.vgltf.unity/Runtime/MaterialExporter.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/MaterialExporter.cs
@@ -134,8 +134,18 @@ namespace VGltf.Unity
             var occlusionTexIndex = ExportOcclusionTextureIfExist(mat, "_OcclusionMap");
             mat.TryGetFloatOrDefault("_OcclusionStrength", 1.0f, out var occlutionStrength);
 
-            mat.TryGetColorOrDefault("_EmissionColor", Color.black, out var emissionColor);
-            var emissionTexIndex = ExportTextureIfExist(mat, "_EmissionMap");
+            Color emissionColor;
+            int? emissionTexIndex;
+            if ((mat.globalIlluminationFlags & MaterialGlobalIlluminationFlags.EmissiveIsBlack) == 0)
+            {
+                mat.TryGetColorOrDefault("_EmissionColor", Color.black, out emissionColor);
+                emissionTexIndex = ExportTextureIfExist(mat, "_EmissionMap");
+            }
+            else
+            {
+                emissionColor = Color.black;
+                emissionTexIndex = null;
+            }
 
             var alphaMode = GetAlphaMode(mat);
             mat.TryGetFloatOrDefault("_Cutoff", 0.0f, out var alphaCutoff);

--- a/Packages/net.yutopp.vgltf.unity/Runtime/MaterialImporter.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/MaterialImporter.cs
@@ -148,6 +148,7 @@ namespace VGltf.Unity
             if (emissionColor != Color.black)
             {
                 mat.EnableKeyword("_EMISSION");
+                mat.globalIlluminationFlags &= ~MaterialGlobalIlluminationFlags.EmissiveIsBlack;
                 mat.SetColor("_EmissionColor", emissionColor);
             }
 


### PR DESCRIPTION
fix two problems
1. Emission was disabled when UnityEditor checks the material (such as opening the materil's inspector)
2. _EmissionColor has been exported even if Emission was disabled