### PR TITLE
Support sampler

### DIFF
--- a/Packages/net.yutopp.vgltf.unity/Runtime/Exporter.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/Exporter.cs
@@ -44,6 +44,7 @@ namespace VGltf.Unity
             public CoordUtils CoordUtils { get; }
 
             public ResourceExporters Exporters { get; }
+            public SamplerExporter SamplerExporter { get; }
 
             public InnerContext(Config config)
             {
@@ -70,6 +71,8 @@ namespace VGltf.Unity
                     Textures = new TextureExporter(this),
                     Images = new ImageExporter(this),
                 };
+
+                SamplerExporter = new SamplerExporter(this);
             }
 
             void IDisposable.Dispose()

--- a/Packages/net.yutopp.vgltf.unity/Runtime/IExporterContext.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/IExporterContext.cs
@@ -18,6 +18,7 @@ namespace VGltf.Unity
         CoordUtils CoordUtils { get; }
 
         ResourceExporters Exporters { get; }
+        SamplerExporter SamplerExporter { get; }
     }
 
     public sealed class ResourceExporters

--- a/Packages/net.yutopp.vgltf.unity/Runtime/IImporterContext.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/IImporterContext.cs
@@ -20,6 +20,7 @@ namespace VGltf.Unity
         ImportingSetting ImportingSetting { get; }
 
         ResourceImporters Importers { get; }
+        SamplerApplier SamplerApplier { get; }
     }
 
     public sealed class ResourceImporters

--- a/Packages/net.yutopp.vgltf.unity/Runtime/Importer.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/Importer.cs
@@ -53,6 +53,7 @@ namespace VGltf.Unity
             public ImportingSetting ImportingSetting { get; }
 
             public ResourceImporters Importers { get; }
+            public SamplerApplier SamplerApplier { get; }
 
             public InnerContext(GltfContainer container, IResourceLoader loader, ITimeSlicer timeSlicer, Config config)
             {
@@ -96,6 +97,8 @@ namespace VGltf.Unity
                     Textures = new TextureImporter(this),
                     Images = new ImageImporter(this),
                 };
+
+                SamplerApplier = new SamplerApplier(this);
             }
 
             public void Dispose()

--- a/Packages/net.yutopp.vgltf.unity/Runtime/SamplerApplier.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/SamplerApplier.cs
@@ -1,0 +1,77 @@
+﻿//
+// Copyright (c) 2019- yutopp (yutopp@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at  https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using System;
+using UnityEngine;
+using VGltf.Types;
+
+namespace VGltf.Unity
+{
+    // https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#samplers
+    public sealed class SamplerApplier
+    {
+        IImporterContext Context { get; }
+
+        public SamplerApplier(IImporterContext context)
+        {
+            Context = context;
+        }
+
+        public void ApplySampler(int? samplerIndex, Texture2D tex)
+        {
+            var gltf = Context.Container.Gltf;
+
+            if (samplerIndex.HasValue)
+            {
+                var sampler = gltf.Samplers[samplerIndex.Value];
+                // UnityEngine.Texture2D has single filterMode, so either one of filters can be used.
+                tex.filterMode = sampler.MinFilter.HasValue ? AsFilterMode(sampler.MinFilter.Value) : FilterMode.Bilinear;
+                tex.wrapModeU = AsWrapMode(sampler.WrapS);
+                tex.wrapModeV = AsWrapMode(sampler.WrapT);
+            }
+            else
+            {
+                // When texture.sampler is undefined, a sampler with repeat wrapping (in both directions) and auto filtering MUST be used.
+                tex.filterMode = FilterMode.Bilinear;
+                tex.wrapMode = TextureWrapMode.Repeat;
+            }
+        }
+
+        static FilterMode AsFilterMode(Sampler.MinFilterEnum minFilterEnum)
+        {
+            switch (minFilterEnum)
+            {
+                case Sampler.MinFilterEnum.NEAREST:
+                case Sampler.MinFilterEnum.NEAREST_MIPMAP_LINEAR:
+                case Sampler.MinFilterEnum.NEAREST_MIPMAP_NEAREST:
+                    return FilterMode.Point;
+                case Sampler.MinFilterEnum.LINEAR:
+                case Sampler.MinFilterEnum.LINEAR_MIPMAP_NEAREST:
+                    return FilterMode.Bilinear;
+                case Sampler.MinFilterEnum.LINEAR_MIPMAP_LINEAR:
+                    return FilterMode.Trilinear;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        static TextureWrapMode AsWrapMode(Sampler.WrapEnum wrapEnum)
+        {
+            switch (wrapEnum)
+            {
+                case Sampler.WrapEnum.ClampToEdge:
+                    return TextureWrapMode.Clamp;
+                case Sampler.WrapEnum.Repeat:
+                    return TextureWrapMode.Repeat;
+                case Sampler.WrapEnum.MirroredRepeat:
+                    return TextureWrapMode.Mirror;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Packages/net.yutopp.vgltf.unity/Runtime/SamplerApplier.cs.meta
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/SamplerApplier.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 57b69a3f33bc4bd99d12fb83942fcd10
+timeCreated: 1661075659

--- a/Packages/net.yutopp.vgltf.unity/Runtime/SamplerExporter.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/SamplerExporter.cs
@@ -1,0 +1,83 @@
+﻿//
+// Copyright (c) 2019- yutopp (yutopp@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at  https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using System;
+using UnityEngine;
+using VGltf.Types;
+using VGltf.Types.Extensions;
+using Texture = UnityEngine.Texture;
+
+namespace VGltf.Unity
+{
+    public class SamplerExporter
+    {
+        IExporterContext Context { get; }
+
+        public SamplerExporter(IExporterContext context)
+        {
+            Context = context;
+        }
+
+        public int RawExport(Texture tex)
+        {
+            var gltfSampler = new Sampler
+            {
+                MagFilter = AsMagFilterEnum(tex.filterMode),
+                MinFilter = AsMinFilterEnum(tex.filterMode),
+                WrapS = AsWrapEnum(tex.wrapModeU),
+                WrapT = AsWrapEnum(tex.wrapModeV),
+            };
+
+            return Context.Gltf.AddSampler(gltfSampler);
+        }
+
+        static Sampler.MagFilterEnum AsMagFilterEnum(FilterMode filterMode)
+        {
+            switch (filterMode)
+            {
+                case FilterMode.Point:
+                    return Sampler.MagFilterEnum.NEAREST;
+                case FilterMode.Bilinear:
+                case FilterMode.Trilinear:
+                    return Sampler.MagFilterEnum.LINEAR;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        static Sampler.MinFilterEnum AsMinFilterEnum(FilterMode filterMode)
+        {
+            switch (filterMode)
+            {
+                case FilterMode.Point:
+                    return Sampler.MinFilterEnum.NEAREST;
+                case FilterMode.Bilinear:
+                    return Sampler.MinFilterEnum.LINEAR;
+                case FilterMode.Trilinear:
+                    return Sampler.MinFilterEnum.LINEAR_MIPMAP_LINEAR;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        static Sampler.WrapEnum AsWrapEnum(TextureWrapMode wrapMode)
+        {
+            switch (wrapMode)
+            {
+                case TextureWrapMode.Clamp:
+                    return Sampler.WrapEnum.ClampToEdge;
+                case TextureWrapMode.Repeat:
+                    return Sampler.WrapEnum.Repeat;
+                case TextureWrapMode.Mirror:
+                case TextureWrapMode.MirrorOnce:
+                    return Sampler.WrapEnum.MirroredRepeat;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Packages/net.yutopp.vgltf.unity/Runtime/SamplerExporter.cs.meta
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/SamplerExporter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 93c9c21d3c4743a687d5ee13b1554457
+timeCreated: 1661072198

--- a/Packages/net.yutopp.vgltf.unity/Runtime/TextureExporter.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/TextureExporter.cs
@@ -37,12 +37,13 @@ namespace VGltf.Unity
             )
         {
             var imageIndex = Context.Exporters.Images.RawExport(tex, isLinear, mat);
+            var samplerIndex = Context.SamplerExporter.RawExport(tex);
 
             var gltfImage = new Types.Texture
             {
                 Name = tex.name,
 
-                //Sampler = primitives,
+                Sampler = samplerIndex,
                 Source = imageIndex,
             };
             var texIndex = Context.Gltf.AddTexture(gltfImage);

--- a/Packages/net.yutopp.vgltf.unity/Runtime/TextureImporter.cs
+++ b/Packages/net.yutopp.vgltf.unity/Runtime/TextureImporter.cs
@@ -62,8 +62,7 @@ namespace VGltf.Unity
                 tex.name = gltfTex.Name;
             }
 
-            // When texture.sampler is undefined, a sampler with repeat wrapping (in both directions) and auto filtering MUST be used.
-            // NOTE: Not implemented currently
+            Context.SamplerApplier.ApplySampler(gltfTex.Sampler, tex);
 
             return tex;
         }


### PR DESCRIPTION
resolve #23

concerns:
- their unmatched names (Exporter / Applier) 
- locations in [Importer|Exporter]Context (they must not be in resources, but not certain current location is)
- arguments of ApplySampler (the index is nullable, in order to avoid that the TextureImporter knows the default sampler settings)