### PR TITLE
To be able to use only MaterialExporterBrigde

### DIFF
--- a/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/Bridge/IExporterBridge.cs
+++ b/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/Bridge/IExporterBridge.cs
@@ -10,12 +10,11 @@ using VGltf.Unity;
 
 namespace VGltf.Ext.Vrm0.Unity.Bridge
 {
-    public interface IExporterBridge
+    public interface IExporterBridge : IMaterialExporterBridge
     {
         void ExportMeta(Exporter exporter, VGltf.Ext.Vrm0.Types.Vrm vrm, GameObject go);
         void ExportFirstPerson(IExporterContext context, VGltf.Ext.Vrm0.Types.Vrm vrm, GameObject go);
         void ExportBlendShapeMaster(Exporter exporter, VGltf.Ext.Vrm0.Types.Vrm vrm, GameObject go);
         void ExportSecondaryAnimation(IExporterContext context, VGltf.Ext.Vrm0.Types.Vrm vrm, GameObject go);
-        Types.Material CreateMaterialProp(IExporterContext context, Material matRes);
     }
 }

--- a/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/Bridge/IMaterialExporterBridge.cs
+++ b/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/Bridge/IMaterialExporterBridge.cs
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2021 - yutopp (yutopp@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at  https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using UnityEngine;
+using VGltf.Unity;
+
+namespace VGltf.Ext.Vrm0.Unity.Bridge
+{
+    public interface IMaterialExporterBridge
+    {
+        Types.Material CreateMaterialProp(IExporterContext context, Material matRes);
+    }
+}

--- a/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/Bridge/IMaterialExporterBridge.cs.meta
+++ b/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/Bridge/IMaterialExporterBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5124880932734639b3826ae453e9762
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/DefaultExporterBridge.cs
+++ b/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/DefaultExporterBridge.cs
@@ -15,6 +15,8 @@ namespace VGltf.Ext.Vrm0.Unity
 {
     public sealed class DefaultExporterBridge : VGltf.Ext.Vrm0.Unity.Bridge.IExporterBridge
     {
+        private readonly DefaultMaterialExporterBridge _materialExporterBridge = new ();
+
         public void ExportMeta(Exporter exporter, VGltf.Ext.Vrm0.Types.Vrm vrm, GameObject go)
         {
             var meta = go.GetComponent<VRM0Meta>();
@@ -198,18 +200,8 @@ namespace VGltf.Ext.Vrm0.Unity
             vrm.SecondaryAnimation = vrmSecondaryAnimation;
         }
 
-        public Types.Material CreateMaterialProp(IExporterContext context, Material mat)
-        {
-            var vrmMat = new Types.Material();
-
-            // TODO: if mat.shader is MToon, support that
-
-            vrmMat.Name = mat.name;
-            vrmMat.Shader = Types.Material.VRM_USE_GLTFSHADER;
-
-            return vrmMat;
-        }
-
+        public Types.Material CreateMaterialProp(IExporterContext context, Material mat) => _materialExporterBridge.CreateMaterialProp(context, mat);
+        
         static Types.BlendShape.GroupType.BlendShapePresetEnum ToVRM0Preset(VRM0BlendShapeProxy.BlendShapePreset kind)
         {
             switch (kind)

--- a/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/DefaultMaterialExporterBrigde.cs
+++ b/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/DefaultMaterialExporterBrigde.cs
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2021 - yutopp (yutopp@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at  https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using UnityEngine;
+using VGltf.Unity;
+
+namespace VGltf.Ext.Vrm0.Unity
+{
+    public sealed class DefaultMaterialExporterBridge : VGltf.Ext.Vrm0.Unity.Bridge.IMaterialExporterBridge
+    {
+        public Types.Material CreateMaterialProp(IExporterContext context, Material mat)
+        {
+            var vrmMat = new Types.Material();
+
+            // TODO: if mat.shader is MToon, support that
+
+            vrmMat.Name = mat.name;
+            vrmMat.Shader = Types.Material.VRM_USE_GLTFSHADER;
+
+            return vrmMat;
+        }
+    }
+}

--- a/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/DefaultMaterialExporterBrigde.cs.meta
+++ b/Packages/net.yutopp.vgltf.ext.vrm0.unity/Runtime/DefaultMaterialExporterBrigde.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fef5335f0cc0d4fd2831cf6c4b61a078
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
マテリアルのexportのみ参照したいシチュエーションがあったので、それぞれ独立したinterfaceと実装を用意しました